### PR TITLE
Scope separator for Jawbone's API should be a space character.

### DIFF
--- a/lib/passport-jawbone/strategy.js
+++ b/lib/passport-jawbone/strategy.js
@@ -9,7 +9,7 @@ function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://jawbone.com/auth/oauth2/auth';
   options.tokenURL = options.tokenURL || 'https://jawbone.com/auth/oauth2/token';
-  options.scopeSeparator = options.scopeSeparator || ',';
+  options.scopeSeparator = options.scopeSeparator || ' ';
   options.customHeaders = options.customHeaders || {};
 
   if (!options.customHeaders['User-Agent']) {

--- a/lib/passport-jawbone/strategy.js
+++ b/lib/passport-jawbone/strategy.js
@@ -7,8 +7,8 @@ var util = require('util'),
 
 function Strategy(options, verify) {
   options = options || {};
-  options.authorizationURL = options.authorizationURL || 'https://jawbone.com/auth/oauth2/auth';
-  options.tokenURL = options.tokenURL || 'https://jawbone.com/auth/oauth2/token';
+  options.authorizationURL = options.authorizationURL || 'https://ios-api.jawbone.com/auth/oauth2/auth';
+  options.tokenURL = options.tokenURL || 'https://ios-api.jawbone.com/auth/oauth2/token';
   options.scopeSeparator = options.scopeSeparator || ' ';
   options.customHeaders = options.customHeaders || {};
 
@@ -18,7 +18,7 @@ function Strategy(options, verify) {
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'jawbone';
-  this._userProfileURL = options.userProfileURL || 'https://jawbone.com/nudge/api/v.1.1/users/@me';
+  this._userProfileURL = options.userProfileURL || 'https://ios-api.jawbone.com/nudge/api/v.1.1/users/@me';
 }
 
 /**


### PR DESCRIPTION
The scope separate for Jawbone's API is documented as a space and not a comma:

https://jawbone.com/up/developer/authentication (see 1.C for space-delimited list)